### PR TITLE
switch http port so it doesnt conflict with Kai (8080) if running

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# switch http port so it doesnt conflict with Kai (8080)
+%dev.quarkus.http.port=8888
+
 # datasource config
 quarkus.datasource.db-kind=postgresql
 quarkus.hibernate-orm.database.generation=none


### PR DESCRIPTION
Switching quarkus dev mode port to 8888 so it doesnt conflict with Kai backend incase they are both running on the same machine. 