### PR TITLE
:bug: Fix improper postgres naming scheme

### DIFF
--- a/quarkus-deploy.md
+++ b/quarkus-deploy.md
@@ -1,3 +1,38 @@
+# Deploying the application on Kubernetes
+
+## Minikube instructions
+
+First, make sure that you have Docker and minikube installed.
+
+Next, point your shell to minikube's docker daemon:
+
+```bash
+minikube start --driver=docker
+```
+
+Then, install postgres into the cluster with the following commands in order:
+
+```bash
+kubectl apply -f deploy/kubernetes/persistent-volume.yaml
+kubectl apply -f deploy/kubernetes/persistent-volume-claim.yaml
+kubectl apply -f deploy/kubernetes/postgresql-deployment.yaml
+kubectl apply -f deploy/kubernetes/postgresql-service.yaml
+```
+
+Next, build the project:
+
+```bash
+mvn clean compile package -Dquarkus.kubernetes.deploy=true
+```
+
+Then, get the URL of the project via:
+
+```bash
+minikube service list
+```
+
+## Openshift instructions
+
 To deploy to Openshift via the Openshift extension
 
 ```bash 
@@ -11,6 +46,6 @@ oc new-app -e POSTGRESQL_USER=quarkus \
 Make sure that you are logged in via terminal to OpenShift via the `oc` command
 
 ```mvn
-            mvn clean compile package -Dquarkus.kubernetes.deploy=true
+mvn clean compile package -Dquarkus.kubernetes.deploy=true
 ```
 

--- a/quarkus-deploy.md
+++ b/quarkus-deploy.md
@@ -5,7 +5,7 @@ oc new-app -e POSTGRESQL_USER=quarkus \
             -e POSTGRESQL_PASSWORD=quarkus \
             -e POSTGRESQL_DATABASE=coolstore \
             openshift/postgresql:latest \
-            --name=coolstore-database
+            --name=postgres
 ``` 
 
 Make sure that you are logged in via terminal to OpenShift via the `oc` command

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,7 +12,7 @@ quarkus.rest-client.shipping-service-api.url=http://localhost:8080/services
 #production profile
 %prod.quarkus.datasource.username=quarkus
 %prod.quarkus.datasource.password=quarkus
-%prod.quarkus.datasource.jdbc.url=jdbc:postgresql://coolstore-database:5432/coolstore
+%prod.quarkus.datasource.jdbc.url=jdbc:postgresql://postgres:5432/coolstore
 
 #openshift deployment
 #quarkus.kubernetes-client.trust-certs=true


### PR DESCRIPTION
When following the directions in the Kai demo mode docs, the server cannot connect to the database as it is named `postgres`, not `coolstore-database` like in the config. This fixes that.